### PR TITLE
Harden CI dependency restore stability

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -28,9 +28,8 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          Rscript -e 'install.packages(c("renv", "remotes"))'
-          Rscript -e 'deps <- unique(na.omit(renv::dependencies()$Package)); deps <- setdiff(deps, rownames(installed.packages())); if (length(deps)) install.packages(deps)'
-          Rscript -e 'remotes::install_github(c("pmcharrison/abcR", "pmcharrison/hrep", "pmcharrison/specdec"), upgrade = "never", dependencies = TRUE)'
+          Rscript -e 'install.packages("remotes")'
+          Rscript -e 'remotes::install_deps(dependencies = TRUE, upgrade = "never")'
       - name: Preflight Python and reticulate
         run: |
           python3 --version

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox python3 python3-venv
+          apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox python3 python3-venv python3-dev
       - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -13,18 +13,15 @@ jobs:
   bookdown:
     name: Render-Book
     runs-on: ubuntu-24.04
+    container:
+      image: rocker/r2u:noble
     steps:
       - uses: actions/checkout@v4
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: '4.3.2' # The R version to download (if necessary) and use.
-      - name: Setup r2u
-        uses: eddelbuettel/github-actions/r2u-setup@master
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox
+          apt-get update
+          apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox
       - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -31,6 +31,10 @@ jobs:
           Rscript -e 'install.packages(c("renv", "remotes"))'
           Rscript -e 'deps <- unique(na.omit(renv::dependencies()$Package)); deps <- setdiff(deps, rownames(installed.packages())); if (length(deps)) install.packages(deps)'
           Rscript -e 'remotes::install_github(c("pmcharrison/abcR", "pmcharrison/hrep", "pmcharrison/specdec"), upgrade = "never", dependencies = TRUE)'
+      - name: Preflight Python and reticulate
+        run: |
+          python3 --version
+          Rscript -e 'reticulate::py_config()'
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -15,13 +15,15 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: rocker/r2u:noble
+    env:
+      RETICULATE_PYTHON: /usr/bin/python3
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox
+          apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox python3 python3-venv
       - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -11,13 +11,13 @@ env:
 jobs:
   bookdown:
     name: Render-Book
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.3.2' # The R version to download (if necessary) and use.
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
       - name: Cache packages
         uses: actions/cache@v4
         with:
@@ -30,7 +30,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox
       - name: Setup renv
-        run: Rscript -e 'install.packages("renv"); renv::restore()'
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Rscript -e 'source("renv/activate.R"); renv::restore(prompt = FALSE)' || \
+          Rscript -e 'source("renv/activate.R"); renv::restore(prompt = FALSE)'
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
       - uses: actions/upload-artifact@v4
@@ -43,11 +47,11 @@ jobs:
 # and also add secrets for a GH_PAT and EMAIL to the repository
 # gh-action from Cecilapp/GitHub-Pages-deploy
   checkout-and-deploy:
-   runs-on: ubuntu-latest
+   runs-on: ubuntu-24.04
    needs: bookdown
    steps:
      - name: Checkout
-       uses: actions/checkout@main
+       uses: actions/checkout@v4
      - name: Download artifact
        uses: actions/download-artifact@v4
        with:

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -9,9 +9,6 @@ on:
 
 name: renderbook
 
-env:
-  RENV_PATHS_ROOT: ~/.local/share/renv
-
 jobs:
   bookdown:
     name: Render-Book
@@ -21,24 +18,20 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.3.2' # The R version to download (if necessary) and use.
+      - name: Setup r2u
+        uses: eddelbuettel/github-actions/r2u-setup@master
       - uses: r-lib/actions/setup-pandoc@v2
-      - name: Cache packages
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-renv-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev libfribidi-dev sox
-      - name: Setup renv
+      - name: Install R dependencies
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          Rscript -e 'source("renv/activate.R"); renv::restore(prompt = FALSE)' || \
-          Rscript -e 'source("renv/activate.R"); renv::restore(prompt = FALSE)'
+          Rscript -e 'install.packages(c("renv", "remotes"))'
+          Rscript -e 'deps <- unique(na.omit(renv::dependencies()$Package)); deps <- setdiff(deps, rownames(installed.packages())); if (length(deps)) install.packages(deps)'
+          Rscript -e 'remotes::install_github(c("pmcharrison/abcR", "pmcharrison/hrep", "pmcharrison/specdec"), upgrade = "never", dependencies = TRUE)'
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -2,6 +2,10 @@ on:
   push:
      branches:
        - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 name: renderbook
 
@@ -49,6 +53,7 @@ jobs:
   checkout-and-deploy:
    runs-on: ubuntu-24.04
    needs: bookdown
+   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
    steps:
      - name: Checkout
        uses: actions/checkout@v4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,46 @@
+Type: Project
+Package: intro.to.music.and.science
+Title: Intro to music and science book project
+Version: 0.0.0.9000
+Description: Dependency manifest for rendering the Intro to Music and Science
+    bookdown project.
+Authors@R: person("Project", "Maintainers", email = "noreply@example.com", role = c("aut", "cre"))
+License: GPL-3
+Encoding: UTF-8
+Depends:
+    R (>= 4.3.2)
+Imports:
+    bookdown (>= 0.37),
+    bslib (>= 0.6.1),
+    cowplot (>= 1.1.2),
+    curl (>= 5.2.0),
+    DiagrammeR (>= 1.0.10),
+    DiagrammeRsvg (>= 0.1),
+    downlit (>= 0.4.3),
+    dplyr (>= 1.1.4),
+    DT (>= 0.31),
+    egg (>= 0.4.5),
+    ggeffects (>= 1.3.4),
+    ggplot2 (>= 3.4.4),
+    ggrepel (>= 0.9.4),
+    gifski (>= 1.32.0),
+    glue (>= 1.6.2),
+    hrep (>= 0.16.1),
+    knitr (>= 1.45),
+    magick (>= 2.8.2),
+    magrittr (>= 2.0.3),
+    MASS (>= 7.3-60),
+    plyr (>= 1.8.9),
+    purrr (>= 1.0.2),
+    R.utils (>= 2.12.3),
+    reticulate (>= 1.34.0),
+    rmarkdown (>= 2.25),
+    rsvg (>= 2.6.0),
+    specdec (>= 0.0.0.9002),
+    svglite (>= 2.1.3),
+    tidyverse (>= 2.0.0),
+    uuid (>= 1.1-1)
+Remotes:
+    pmcharrison/abcR@ddb23ba8e61442b589c36ef93efc6925926411b6,
+    pmcharrison/hrep@216c7e83c2985760f5dddc2d915aaa2e434c97b3,
+    pmcharrison/specdec@b79f11d800fa14e7ad6ab9a9b287130b82f765f0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Intro to music and science book project
 Version: 0.0.0.9000
 Description: Dependency manifest for rendering the Intro to Music and Science
     bookdown project.
-Authors@R: person("Project", "Maintainers", email = "noreply@example.com", role = c("aut", "cre"))
-License: GPL-3
+Authors@R: person("Peter", "Harrison", email = "pmch2@cam.ac.uk", role = c("aut", "cre"))
+License: CC BY-NC-SA 4.0
 Encoding: UTF-8
 Depends:
     R (>= 4.3.2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- modernize core GitHub Actions usage in the book deployment workflow
- pin both jobs to `ubuntu-24.04` to reduce runner-image drift
- enable CI rendering on `pull_request` (targeting `main`) and manual `workflow_dispatch`
- keep deploy restricted to pushes on `main` only via job-level condition
- migrate dependency installation to a looser, binary-first flow
- run the render job inside `rocker/r2u:noble` to use a prebuilt r2u environment
- fix `reticulate` Python discovery in CI by installing Python and setting `RETICULATE_PYTHON=/usr/bin/python3`
- add a preflight diagnostics step (`python3 --version` and `reticulate::py_config()`) before rendering
- install `python3-dev` to provide Python shared library required by `reticulate`
- add a `DESCRIPTION` file as the explicit dependency manifest for CI
  - include direct package dependencies with minimum versions
  - pin GitHub remotes to commit SHAs (`abcR`, `hrep`, `specdec`)
- switch CI install command from renv scanning + hardcoded remotes to `remotes::install_deps(dependencies = TRUE, upgrade = "never")`
- set DESCRIPTION author metadata to Peter Harrison (`pmch2@cam.ac.uk`)
- align DESCRIPTION project license with repo licensing statement (`CC BY-NC-SA 4.0`)

## Why
This keeps your requested r2u-based, less-locked approach while introducing a cleaner single source of truth for direct dependencies and safer pinning for GitHub remotes.

## Validation
- validated workflow YAML parses successfully with `python3 -c "import yaml; yaml.safe_load(...)"`
- validated `DESCRIPTION` format is readable by R (`read.dcf`)
- no files outside workflow/dependency manifest changed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c569379-f0b5-4795-b5a7-333f633dde41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c569379-f0b5-4795-b5a7-333f633dde41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

